### PR TITLE
Update fuzz.txt

### DIFF
--- a/fuzz.txt
+++ b/fuzz.txt
@@ -20236,6 +20236,7 @@
 /.config.php
 /.env
 /.git
+/.gitmodules
 /.git.php
 /.git/config
 /.git/HEAD


### PR DESCRIPTION
The .gitmodules file was exposed on the web server as part of an accessible .git directory.This exposure indicated a misconfiguration that could have allowed attackers to explore the .git directory further and potentially reconstruct or download the full source code repository.